### PR TITLE
Fix for optional arguments

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -63,9 +63,16 @@ module Memoist
     # We don't want to extract out the last argument in this case.
     # Also, if the :memoist_reload flag is passed, we use that
     # irrespective of the arity.
-    if method.arity.negative? || args.include?(:memoist_reload)
-      reload = args.delete :memoist_reload
-      return !reload.nil?
+    if method.arity.negative? && args.length > 0 && args.last.is_a?(Hash)
+      named_args_hash = args.last
+      reload = named_args_hash.delete :memoist_reload
+      # If no other named args were passed, that means memoist_reload is an
+      # extra arg that we need to get rid of; otherwise Ruby will complain
+      # about argument number mismatch.
+      if named_args_hash.empty?
+        args.delete(named_args_hash)
+      end
+      return reload
     end
 
     if args.length == method.arity.abs + 1 && (args.last == true || args.last == :reload)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -59,6 +59,15 @@ module Memoist
   end
 
   def self.extract_reload!(method, args)
+    # Arity is negative for methods with optional/named args
+    # We don't want to extract out the last argument in this case.
+    # Also, if the :memoist_reload flag is passed, we use that
+    # irrespective of the arity.
+    if method.arity.negative? || args.include?(:memoist_reload)
+      reload = args.delete :memoist_reload
+      return !reload.nil?
+    end
+
     if args.length == method.arity.abs + 1 && (args.last == true || args.last == :reload)
       reload = args.pop
     end

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -63,7 +63,7 @@ module Memoist
     # We don't want to extract out the last argument in this case.
     # Also, if the :memoist_reload flag is passed, we use that
     # irrespective of the arity.
-    if method.arity.negative? && args.length > 0 && args.last.is_a?(Hash)
+    if args.length > 0 && args.last.is_a?(Hash)
       named_args_hash = args.last
       reload = named_args_hash.delete :memoist_reload
       # If no other named args were passed, that means memoist_reload is an
@@ -74,8 +74,10 @@ module Memoist
       end
       return reload
     end
+    return false if method.arity.negative?
 
-    if args.length == method.arity.abs + 1 && (args.last == true || args.last == :reload)
+    # Legacy purposes, works only for methods with no optional/named args
+    if args.length == method.arity + 1 && (args.last == true || args.last == :reload)
       reload = args.pop
     end
     reload

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -252,7 +252,7 @@ class MemoistTest < Minitest::Test
 
     # There has been exactly one sleep call due to memoization
     # Now, with reload, we'll have 3 more calls
-    3.times { assert_equal 10, @person.sleep(4, 10,:memoist_reload) }
+    3.times { assert_equal 10, @person.sleep(4, 10, memoist_reload: true) }
     assert_equal 4, @person.sleep_calls
   end
 
@@ -263,7 +263,7 @@ class MemoistTest < Minitest::Test
     3.times { assert_equal true, @person.update_attributes(age: 21, name: 'James') }
     assert_equal 1, @person.update_attributes_calls
 
-    3.times { assert_equal true, @person.update_attributes({ age: 21, name: 'James' }, :memoist_reload) }
+    3.times { assert_equal true, @person.update_attributes({ age: 21, name: 'James' }, memoist_reload: true) }
     assert_equal 4, @person.update_attributes_calls
   end
 

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -67,9 +67,9 @@ class MemoistTest < Minitest::Test
 
     memoize :name, :age
 
-    def sleep(initial_delay, hours = 8, mins = 5)
+    def sleep(hours, mins = 5, seconds: 0)
       @counter.call(:sleep)
-      hours
+      hours * 3600 + mins * 60 + seconds
     end
     memoize :sleep
 
@@ -241,19 +241,25 @@ class MemoistTest < Minitest::Test
 
     3.times { assert_equal 'Josh', @person.name }
     assert_equal 1, @person.name_calls
+
+    3.times { assert_equal 'Josh', @person.name(memoist_reload: true) }
+    assert_equal 4, @person.name_calls
   end
 
   def test_memoize_with_optional_arguments
-    assert_equal 4, @person.sleep(4, 4)
+    assert_equal 15000, @person.sleep(4, 10)
     assert_equal 1, @person.sleep_calls
 
-    3.times { assert_equal 4, @person.sleep(4, 4) }
+    3.times { assert_equal 15000, @person.sleep(4, 10) }
     assert_equal 1, @person.sleep_calls
+
+    3.times { assert_equal 15000, @person.sleep(4, 10, seconds: 0) }
+    assert_equal 2, @person.sleep_calls
 
     # There has been exactly one sleep call due to memoization
     # Now, with reload, we'll have 3 more calls
-    3.times { assert_equal 10, @person.sleep(4, 10, memoist_reload: true) }
-    assert_equal 4, @person.sleep_calls
+    3.times { assert_equal 15000, @person.sleep(4, 10, memoist_reload: true) }
+    assert_equal 5, @person.sleep_calls
   end
 
   def test_memoize_with_options_hash
@@ -295,6 +301,8 @@ class MemoistTest < Minitest::Test
     assert_equal 2, @calculator.counter
     assert_equal 3, @calculator.counter(true)
     assert_equal 3, @calculator.counter
+    assert_equal 4, @calculator.counter(memoist_reload: true)
+    assert_equal 4, @calculator.counter
   end
 
   def test_flush_cache

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -67,7 +67,7 @@ class MemoistTest < Minitest::Test
 
     memoize :name, :age
 
-    def sleep(hours = 8)
+    def sleep(initial_delay, hours = 8, mins = 5)
       @counter.call(:sleep)
       hours
     end
@@ -244,13 +244,15 @@ class MemoistTest < Minitest::Test
   end
 
   def test_memoize_with_optional_arguments
-    assert_equal 4, @person.sleep(4)
+    assert_equal 4, @person.sleep(4, 4)
     assert_equal 1, @person.sleep_calls
 
-    3.times { assert_equal 4, @person.sleep(4) }
+    3.times { assert_equal 4, @person.sleep(4, 4) }
     assert_equal 1, @person.sleep_calls
 
-    3.times { assert_equal 4, @person.sleep(4, :reload) }
+    # There has been exactly one sleep call due to memoization
+    # Now, with reload, we'll have 3 more calls
+    3.times { assert_equal 10, @person.sleep(4, 10,:memoist_reload) }
     assert_equal 4, @person.sleep_calls
   end
 
@@ -261,7 +263,7 @@ class MemoistTest < Minitest::Test
     3.times { assert_equal true, @person.update_attributes(age: 21, name: 'James') }
     assert_equal 1, @person.update_attributes_calls
 
-    3.times { assert_equal true, @person.update_attributes({ age: 21, name: 'James' }, :reload) }
+    3.times { assert_equal true, @person.update_attributes({ age: 21, name: 'James' }, :memoist_reload) }
     assert_equal 4, @person.update_attributes_calls
   end
 


### PR DESCRIPTION
Use a fixed :memoist_reload argument instead of depending on
argument order as it is fragile in case of optional
and named args.
This change maintains backward compatibility for methods that
don't have optional/named arguments.